### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/102/536/005/102536005.geojson
+++ b/data/102/536/005/102536005.geojson
@@ -32,6 +32,9 @@
     "name:kor_x_preferred":[
         "\ub85c\ud0c0 \uad6d\uc81c\uacf5\ud56d"
     ],
+    "name:msa_x_preferred":[
+        "Lapangan Terbang Antarabangsa Rota"
+    ],
     "name:pol_x_preferred":[
         "Port lotniczy Rota"
     ],
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":102536005,
-    "wof:lastmodified":1566611806,
+    "wof:lastmodified":1690939773,
     "wof:name":"Rota International Airport",
     "wof:parent_id":-1,
     "wof:placetype":"campus",

--- a/data/102/536/007/102536007.geojson
+++ b/data/102/536/007/102536007.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":13.0,
+    "name:ces_x_preferred":[
+        "Mezin\u00e1rodn\u00ed leti\u0161t\u011b Saipan"
+    ],
+    "name:cym_x_preferred":[
+        "Maes Awyr Rhyngwladol Saipan"
+    ],
     "name:deu_x_preferred":[
         "Flughafen Saipan"
     ],
@@ -117,7 +123,7 @@
         }
     ],
     "wof:id":102536007,
-    "wof:lastmodified":1566611806,
+    "wof:lastmodified":1690939773,
     "wof:name":"Saipan International Airport",
     "wof:parent_id":-1,
     "wof:placetype":"campus",

--- a/data/114/190/837/1/1141908371.geojson
+++ b/data/114/190/837/1/1141908371.geojson
@@ -93,6 +93,9 @@
     "name:tur_x_preferred":[
         "Capitol Hill"
     ],
+    "name:ukr_x_preferred":[
+        "\u041a\u0430\u043f\u0456\u0442\u043e\u043b\u0456\u0439\u0441\u044c\u043a\u0438\u0439 \u043f\u0430\u0433\u043e\u0440\u0431"
+    ],
     "name:urd_x_preferred":[
         "\u06a9\u06cc\u067e\u0679\u0644 \u06c1\u0644"
     ],
@@ -225,7 +228,7 @@
         }
     ],
     "wof:id":1141908371,
-    "wof:lastmodified":1636504674,
+    "wof:lastmodified":1690939775,
     "wof:name":"Capitol Hill",
     "wof:parent_id":85674803,
     "wof:placetype":"locality",

--- a/data/856/748/01/85674801.geojson
+++ b/data/856/748/01/85674801.geojson
@@ -29,14 +29,23 @@
     "mz:is_current":-1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u062a\u064a\u0646\u064a\u0627\u0646"
+    ],
     "name:ast_x_preferred":[
         "Tini\u00e1n"
+    ],
+    "name:ast_x_variant":[
+        "Tinian"
     ],
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u0422\u044b\u043d\u0456\u044f\u043d"
     ],
     "name:bul_x_preferred":[
         "\u0422\u0438\u043d\u0438\u0430\u043d"
+    ],
+    "name:cat_x_preferred":[
+        "Tinian"
     ],
     "name:ceb_x_preferred":[
         "Tinian Island"
@@ -82,6 +91,9 @@
     ],
     "name:hin_x_preferred":[
         "\u0924\u0940\u0928\u093f\u0905\u0928"
+    ],
+    "name:hun_x_preferred":[
+        "Tinian"
     ],
     "name:hye_x_preferred":[
         "\u054f\u056b\u0576\u056b\u0561\u0576"
@@ -142,6 +154,12 @@
     ],
     "name:tha_x_preferred":[
         "\u0e17\u0e34\u0e40\u0e19\u0e35\u0e22\u0e19"
+    ],
+    "name:tur_x_preferred":[
+        "Tinian Adas\u0131"
+    ],
+    "name:uig_x_preferred":[
+        "\u062a\u064a\u06d5\u0646\u0646\u0649\u06ad \u0626\u0627\u0631\u0649\u0644\u0649"
     ],
     "name:ukr_x_preferred":[
         "\u0422\u0456\u043d\u0456\u0430\u043d"
@@ -273,7 +291,7 @@
         "wd:id":"Q325652"
     },
     "wof:country":"MP",
-    "wof:geomhash":"410c59bddbad9a67bfe5bfaf4fddeef5",
+    "wof:geomhash":"e601bc1bf06d1a28cdfe58a55d12549a",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -290,7 +308,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1684438875,
+    "wof:lastmodified":1690939774,
     "wof:name":"Tinian",
     "wof:parent_id":85632421,
     "wof:placetype":"region",

--- a/data/856/748/03/85674803.geojson
+++ b/data/856/748/03/85674803.geojson
@@ -32,11 +32,20 @@
     "name:afr_x_preferred":[
         "Saipan"
     ],
+    "name:ami_x_preferred":[
+        "Saipan"
+    ],
     "name:ara_x_preferred":[
+        "\u0633\u0627\u064a\u0628\u0627\u0646"
+    ],
+    "name:arz_x_preferred":[
         "\u0633\u0627\u064a\u0628\u0627\u0646"
     ],
     "name:ast_x_preferred":[
         "Saip\u00e1n"
+    ],
+    "name:azb_x_preferred":[
+        "\u0633\u0627\u06cc\u067e\u0627\u0646"
     ],
     "name:aze_x_preferred":[
         "Saypan"
@@ -60,6 +69,9 @@
         "Saipan Island"
     ],
     "name:ces_x_preferred":[
+        "Saipan"
+    ],
+    "name:cym_x_preferred":[
         "Saipan"
     ],
     "name:dan_x_preferred":[
@@ -92,6 +104,9 @@
     "name:fra_x_preferred":[
         "Saipan"
     ],
+    "name:fra_x_variant":[
+        "Sa\u00efpan"
+    ],
     "name:fry_x_preferred":[
         "Saipan"
     ],
@@ -107,7 +122,13 @@
     "name:hin_x_preferred":[
         "\u0938\u093e\u0907\u092a\u0948\u0928"
     ],
+    "name:hin_x_variant":[
+        "\u0938\u0948\u092a\u093e\u0928"
+    ],
     "name:hrv_x_preferred":[
+        "Saipan"
+    ],
+    "name:hun_x_preferred":[
         "Saipan"
     ],
     "name:hye_x_preferred":[
@@ -115,6 +136,9 @@
     ],
     "name:ind_x_preferred":[
         "Saipan"
+    ],
+    "name:isl_x_preferred":[
+        "Sa\u00edpan"
     ],
     "name:ita_x_preferred":[
         "Saipan"
@@ -131,6 +155,12 @@
     "name:kor_x_variant":[
         "\uc0ac\uc774\ud310",
         "\uc0ac\uc774\ud310\uc12c"
+    ],
+    "name:lav_x_preferred":[
+        "Saipana"
+    ],
+    "name:lij_x_preferred":[
+        "Saipan"
     ],
     "name:lit_x_preferred":[
         "Saipanas"
@@ -159,11 +189,23 @@
     "name:oci_x_preferred":[
         "Saipan"
     ],
+    "name:pan_x_preferred":[
+        "\u0a38\u0a3e\u0a08\u0a2a\u0a28"
+    ],
+    "name:pnb_x_preferred":[
+        "\u0633\u0627\u0626\u067e\u06cc\u0646"
+    ],
     "name:pol_x_preferred":[
         "Saipan"
     ],
     "name:por_x_preferred":[
         "Saipan"
+    ],
+    "name:por_x_variant":[
+        "Saip\u00e3"
+    ],
+    "name:pus_x_preferred":[
+        "\u0633\u0627\u06cc\u067e\u0627\u0646"
     ],
     "name:ron_x_preferred":[
         "Saipan"
@@ -183,6 +225,9 @@
     "name:spa_x_preferred":[
         "Saip\u00e1n"
     ],
+    "name:srd_x_preferred":[
+        "Saipan"
+    ],
     "name:srp_x_preferred":[
         "\u0421\u0430\u0458\u043f\u0430\u043d"
     ],
@@ -191,6 +236,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0b9a\u0bc8\u0baa\u0bcd\u0baa\u0bc7\u0ba9\u0bcd"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0421\u0430\u0439\u043f\u0430\u043d"
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e01\u0e32\u0e30\u0e44\u0e0b\u0e1b\u0e31\u0e19"
@@ -334,7 +382,7 @@
         "wd:id":"Q51679"
     },
     "wof:country":"MP",
-    "wof:geomhash":"6a4eb4e7163354137cb701052ea60d92",
+    "wof:geomhash":"4e15b7877907d8e5b173ee283080bdbd",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -351,7 +399,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1684438875,
+    "wof:lastmodified":1690939774,
     "wof:name":"Saipan",
     "wof:parent_id":85632421,
     "wof:placetype":"region",

--- a/data/890/435/317/890435317.geojson
+++ b/data/890/435/317/890435317.geojson
@@ -19,6 +19,12 @@
     "mz:is_current":-1,
     "mz:is_funky":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0631\u0648\u062a\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Islla Rota"
+    ],
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u0420\u043e\u0442\u0430"
     ],
@@ -30,6 +36,9 @@
     ],
     "name:cal_x_preferred":[
         "Luuta"
+    ],
+    "name:cat_x_preferred":[
+        "Rota"
     ],
     "name:ceb_x_preferred":[
         "Rota Island"
@@ -54,6 +63,9 @@
     ],
     "name:est_x_preferred":[
         "Rota saar"
+    ],
+    "name:eus_x_preferred":[
+        "Rota"
     ],
     "name:fas_x_preferred":[
         "\u0631\u0648\u062a\u0627"
@@ -162,7 +174,7 @@
         }
     ],
     "wof:id":890435317,
-    "wof:lastmodified":1566611811,
+    "wof:lastmodified":1690939775,
     "wof:name":"Rota Island",
     "wof:parent_id":85674797,
     "wof:placetype":"locality",

--- a/data/890/447/901/890447901.geojson
+++ b/data/890/447/901/890447901.geojson
@@ -19,6 +19,15 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:arz_x_preferred":[
+        "\u062c\u0628\u0644 \u0627\u0644\u0627\u0645\u0627\u062c\u0627\u0646"
+    ],
+    "name:ast_x_preferred":[
+        "Alamagan"
+    ],
+    "name:cat_x_preferred":[
+        "Alamagan"
+    ],
     "name:ces_x_preferred":[
         "Alamagan"
     ],
@@ -52,6 +61,9 @@
     "name:hye_x_preferred":[
         "\u0531\u056c\u0561\u0574\u0561\u0563\u0561\u0576"
     ],
+    "name:ind_x_preferred":[
+        "Alamagan"
+    ],
     "name:ita_x_preferred":[
         "Alamagan"
     ],
@@ -60,6 +72,9 @@
     ],
     "name:kat_x_preferred":[
         "\u10d0\u10da\u10d0\u10db\u10d0\u10d2\u10d0\u10dc\u10d8"
+    ],
+    "name:lld_x_preferred":[
+        "Alamagan"
     ],
     "name:msa_x_preferred":[
         "Gunung Berapi Alamagan"
@@ -91,6 +106,9 @@
     "name:urd_x_preferred":[
         "\u0627\u0644\u0627\u0645\u0627\u06af\u0627\u0646"
     ],
+    "name:vec_x_preferred":[
+        "Alamagan"
+    ],
     "name:zho_x_preferred":[
         "\u963f\u62c9\u6728\u6839"
     ],
@@ -120,7 +138,7 @@
         }
     ],
     "wof:id":890447901,
-    "wof:lastmodified":1566611810,
+    "wof:lastmodified":1690939774,
     "wof:name":"Alamagan Village",
     "wof:parent_id":-1,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.