### PR TITLE
mp concordances, placetype local, and more

### DIFF
--- a/data/856/747/97/85674797.geojson
+++ b/data/856/747/97/85674797.geojson
@@ -229,6 +229,7 @@
         "qs_pg:id":386004,
         "uscensus:geoid":"69100"
     },
+    "wof:concordances_official":"uscensus:geoid",
     "wof:country":"MP",
     "wof:geomhash":"6ac04c641824debeff2e510522fa9a88",
     "wof:hierarchy":[
@@ -247,7 +248,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1684438875,
+    "wof:lastmodified":1695885335,
     "wof:name":"Rota",
     "wof:parent_id":85632421,
     "wof:placetype":"region",

--- a/data/856/748/01/85674801.geojson
+++ b/data/856/748/01/85674801.geojson
@@ -26,7 +26,7 @@
     "mps:latitude":14.99353,
     "mps:longitude":145.623208,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -290,8 +290,9 @@
         "uscensus:geoid":"69120",
         "wd:id":"Q325652"
     },
+    "wof:concordances_official":"uscensus:geoid",
     "wof:country":"MP",
-    "wof:geomhash":"e601bc1bf06d1a28cdfe58a55d12549a",
+    "wof:geomhash":"410c59bddbad9a67bfe5bfaf4fddeef5",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -308,7 +309,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690939774,
+    "wof:lastmodified":1695884323,
     "wof:name":"Tinian",
     "wof:parent_id":85632421,
     "wof:placetype":"region",

--- a/data/856/748/03/85674803.geojson
+++ b/data/856/748/03/85674803.geojson
@@ -381,8 +381,9 @@
         "uscensus:geoid":"69110",
         "wd:id":"Q51679"
     },
+    "wof:concordances_official":"uscensus:geoid",
     "wof:country":"MP",
-    "wof:geomhash":"4e15b7877907d8e5b173ee283080bdbd",
+    "wof:geomhash":"6a4eb4e7163354137cb701052ea60d92",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -399,7 +400,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690939774,
+    "wof:lastmodified":1695885335,
     "wof:name":"Saipan",
     "wof:parent_id":85632421,
     "wof:placetype":"region",

--- a/data/856/748/09/85674809.geojson
+++ b/data/856/748/09/85674809.geojson
@@ -145,6 +145,7 @@
         "qs_pg:id":43518,
         "uscensus:geoid":"69085"
     },
+    "wof:concordances_official":"uscensus:geoid",
     "wof:country":"MP",
     "wof:geomhash":"698fc8b482338507a0539467413b2837",
     "wof:hierarchy":[
@@ -163,7 +164,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1684438875,
+    "wof:lastmodified":1695885335,
     "wof:name":"Northern Islands",
     "wof:parent_id":85632421,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.